### PR TITLE
Ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+# Mac Finder files.
+.DS_Store


### PR DESCRIPTION
A .DS_Store is a [Mac-specific hidden file](http://en.wikipedia.org/wiki/.DS_Store) and is not something that you generally want to add to source control, as its contents may change without you necessarily interacting with it.

https://stackoverflow.com/questions/30246832/is-ds-store-file-important